### PR TITLE
Add operator to concatenate URL fragments

### DIFF
--- a/canteven-url.cabal
+++ b/canteven-url.cabal
@@ -21,6 +21,6 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base >=4.7 && <4.8,
-                       text
+                       text >=1.2 && <1.3
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/canteven-url.cabal
+++ b/canteven-url.cabal
@@ -17,9 +17,10 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
-  -- exposed-modules:     
+  exposed-modules:     Canteven.Url
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.7 && <4.8
-  -- hs-source-dirs:      
+  build-depends:       base >=4.7 && <4.8,
+                       text
+  hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Canteven/Url.hs
+++ b/src/Canteven/Url.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Canteven.Url(
+    URL,
+    (</>)
+  ) where
+
+import Data.Monoid ((<>))
+import Data.Text (Text, dropWhileEnd)
+
+import qualified Data.Text as T (dropWhile)
+
+type URL = Text
+
+-- |Concatenates a URL and a string of text, and puts a `/` between them. Strips
+-- away any `/` characters from the end of the first parameter and the start of
+-- the second parameter. Doesn't do any URL-parsing or URL-validation.
+(</>) :: URL -> Text -> URL
+a </> b = a' <> "/" <> b'
+  where
+    a' = dropWhileEnd (== '/') a
+    b' = T.dropWhile (== '/') b


### PR DESCRIPTION
First pass on adding an operator that will:

- take two `Text` arguments,
- strip away all slashes from the end of the first element
- strip away all slashes from the start of the second element
- concatenate the two stripped arguments with a slash in between

Note that this operator doesn't currently do any intelligent checking
about the status or relationship of the two arguments; all it can
guarantee is that the output will be the concatenation of the two
arguments with exactly one slash in between.